### PR TITLE
fix, refactor dark mode

### DIFF
--- a/public/scripts/darkMode.js
+++ b/public/scripts/darkMode.js
@@ -11,15 +11,19 @@ function handleHover(button, isHover) {
 
 window.onload = function () {
   if (localStorage.getItem("darkMode") === "enabled") {
-    document.body.classList.add("dark-mode");
+    document.documentElement.style.setProperty("--bg", "var(--dark-bg-color)");
+    document.documentElement.style.setProperty("--fg", "var(--off-white)");
   }
 };
 
 function darkModeToggle() {
-  document.body.classList.toggle("dark-mode");
-  if (document.body.classList.contains("dark-mode")) {
+  if (document.documentElement.style.getPropertyValue("--bg") !== "var(--dark-bg-color)") {
+    document.documentElement.style.setProperty("--bg", "var(--dark-bg-color)");
+    document.documentElement.style.setProperty("--fg", "var(--off-white)");
     localStorage.setItem("darkMode", "enabled");
   } else {
+    document.documentElement.style.setProperty("--bg", "var(--light-bg-color)");
+    document.documentElement.style.setProperty("--fg", "var(--near-black)");
     localStorage.setItem("darkMode", "disabled");
   }
 }

--- a/public/scripts/themeInit.js
+++ b/public/scripts/themeInit.js
@@ -5,6 +5,7 @@
 
   //Apply dark mode if enabled in storage or no preference but system pref is dark
   if (storedPreference === "enabled" || (storedPreference === null && prefersDark)) {
-    document.documentElement.classList.add("dark-mode");
+    document.documentElement.style.setProperty("--bg", "var(--dark-bg-color)");
+    document.documentElement.style.setProperty("--fg", "var(--off-white)");
   }
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -9,6 +9,9 @@
   --link-active:    #0000ff;
   --dark-grey:      #414141;
   --light-grey:     #7e7e7e;
+
+  --bg:         var(--light-bg-color);
+  --fg:         var(--near-black);
 }
 /*
 * {
@@ -21,8 +24,8 @@
 }
 */
 body {
-  background-color: var(--light-bg-color);
-  color: var(--near-black);
+  background-color: var(--bg);
+  color: var(--fg);
   font-family: 'Consolas';
   height: 100vh;
 }


### PR DESCRIPTION
themeInit.js, which updates the style before html render, can only add the dark-mode class to the root element. The styles in that class were designed to apply to the body element, so in cases when the browser prefers dark the script functions incorrectly.

Instead of adding classes, all elements rely on css variables that can be updated depending on the preference. This solves the problem because they can be changed in the root element before html render, and in my experience this makes implementing the color change in other elements easier.